### PR TITLE
Fix/typo corrections

### DIFF
--- a/internal/provider/app_resource.go
+++ b/internal/provider/app_resource.go
@@ -171,7 +171,7 @@ func (r flyAppResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequ
 	tflog.Info(ctx, fmt.Sprintf("existing: %+v, new: %+v", state, plan))
 
 	if !plan.Org.Unknown && plan.Org.Value != state.Org.Value {
-		resp.Diagnostics.AddError("Can't mutate org of existing app", "Can't swith org"+state.Org.Value+" to "+plan.Org.Value)
+		resp.Diagnostics.AddError("Can't mutate org of existing app", "Can't switch org"+state.Org.Value+" to "+plan.Org.Value)
 	}
 	if !plan.Name.Unknown && plan.Name.Value != state.Name.Value {
 		resp.Diagnostics.AddError("Can't mutate Name of existing app", "Can't switch name "+state.Name.Value+" to "+plan.Name.Value)

--- a/internal/provider/machine_resource.go
+++ b/internal/provider/machine_resource.go
@@ -525,10 +525,10 @@ func (mr flyMachineResource) Update(ctx context.Context, req tfsdk.UpdateResourc
 	}
 
 	if !state.Name.Unknown && plan.Name.Value != state.Name.Value {
-		resp.Diagnostics.AddError("Can't mutate name of existing machine", "Can't swith name "+state.Name.Value+" to "+plan.Name.Value)
+		resp.Diagnostics.AddError("Can't mutate name of existing machine", "Can't switch name "+state.Name.Value+" to "+plan.Name.Value)
 	}
 	if !state.Region.Unknown && plan.Region.Value != state.Region.Value {
-		resp.Diagnostics.AddError("Can't mutate region of existing machine", "Can't swith region "+state.Name.Value+" to "+plan.Name.Value)
+		resp.Diagnostics.AddError("Can't mutate region of existing machine", "Can't switch region "+state.Name.Value+" to "+plan.Name.Value)
 	}
 
 	services := TfServicesToServices(plan.Services)


### PR DESCRIPTION
Fixes instances where 'switch' has been misspelled as 'swith' (missing 'c') in error messages. 

Should have no effect on functionality. `go test ./...` comes up `ok`.