### PR TITLE
Allow service handlers to be empty for passthrough traffic

### DIFF
--- a/internal/provider/machine_resource.go
+++ b/internal/provider/machine_resource.go
@@ -175,7 +175,7 @@ func (mr flyMachineResourceType) GetSchema(context.Context) (tfsdk.Schema, diag.
 							},
 							"handlers": {
 								MarkdownDescription: "How the edge should process requests",
-								Required:            true,
+								Optional:            true,
 								Type:                types.ListType{ElemType: types.StringType},
 							},
 						}),


### PR DESCRIPTION
Passthrough is only possible by *not* setting the `handlers` section: https://fly.io/docs/reference/services/#tcp-pass-through

Fly Machines API reference allows for empty handlers if passthrough is desired: https://github.com/superfly/flyctl/blob/b378787f6f6af061eb4494c74fde8edc876fd091/api/machine_types.go#L150

The Terraform provider, however, mandates a value for this field which means passthrough cannot be used. This PR changes the behavior of the provider to make the `handlers` param optional.

### Test Terraform code
```
resource "fly_machine" "coordinator" {
  for_each = toset(var.regions)
  app      = fly_app.coordinator.name
  region   = each.value
  name     = "${fly_app.coordinator.name}-${each.value}"
  image    = var.image_name
  cpus     = 1
  cputype  = "shared"
  memorymb = 256
  services = [
    {
      ports = [
        {
          port     = 443
          handlers = ["tls", "http"]
        },
        {
          port     = 80
          handlers = ["http"]
        }
      ]
      "protocol" : "tcp",
      "internal_port" : 8080,
    },
    {
      "internal_port" : 7147,
      protocol : "tcp",
      ports : [
        {
          port : 7147,
        }
      ]
    }
  ]
  depends_on = [fly_app.coordinator]
}
```

### Before
```
% terraform apply  

│ Error: Incorrect attribute value type
│ 
│   on main.tf line 22, in resource "fly_machine" "coordinator":
│   22:   services = [
│   23:     {
│   24:       ports = [
│   25:         {
│   26:           port     = 443
│   27:           handlers = ["tls", "http"]
│   28:         },
│   29:         {
│   30:           port     = 80
│   31:           handlers = ["http"]
│   32:         }
│   33:       ]
│   34:       "protocol" : "tcp",
│   35:       "internal_port" : 8080,
│   36:     },
│   37:     {
│   38:       "internal_port" : 7147,
│   39:       protocol : "tcp",
│   40:       ports : [
│   41:         {
│   42:           port : 7147,
│   43:         }
│   44:       ]
│   45:     }
│   46:   ]
│ 
│ Inappropriate value for attribute "services": element 1: attribute "ports": element 0: attribute "handlers" is
│ required.
```

### After
```
% terraform apply  
...
  # fly_machine.coordinator["ewr"] will be created
  + resource "fly_machine" "coordinator" {
      + app      = "hathora-games-coordinator"
      + cpus     = 1
      + cputype  = "shared"
      + env      = (known after apply)
      + id       = (known after apply)
      + image    = "registry.fly.io/hathora-games-coordinator:deployment-01GBSNQ3CVFZJHTDXE2MPMB3SK"
      + memorymb = 256
      + name     = "hathora-games-coordinator-ewr"
      + region   = "ewr"
      + services = [
          + {
              + internal_port = 8080
              + ports         = [
                  + {
                      + handlers = [
                          + "tls",
                          + "http",
                        ]
                      + port     = 443
                    },
                  + {
                      + handlers = [
                          + "http",
                        ]
                      + port     = 80
                    },
                ]
              + protocol      = "tcp"
            },
          + {
              + internal_port = 7147
              + ports         = [
                  + {
                      + port = 7147
                    },
                ]
              + protocol      = "tcp"
            },
        ]
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```