### PR TITLE
Update references to fly API token env variable

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ description: |-
 
 ```terraform
 provider "fly" {
-  # Please don't do this. Use the FLY_TOKEN env variable instead.
+  # Please don't do this. Use the FLY_API_TOKEN env variable instead.
   flytoken = "abc123"
 }
 ```

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,4 +1,4 @@
 provider "fly" {
-  # Please don't do this. Use the FLY_TOKEN env variable instead.
+  # Please don't do this. Use the FLY_API_TOKEN env variable instead.
   flytoken = "abc123"
 }


### PR DESCRIPTION
The documentation code snippets reference `FLY_TOKEN`, but the _actual_ variable is `FLY_API_TOKEN`. This PR updates that.