### PR TITLE
Log machine create http errors

### DIFF
--- a/pkg/apiv1/machines.go
+++ b/pkg/apiv1/machines.go
@@ -157,7 +157,7 @@ func (a *MachineAPI) CreateMachine(req MachineCreateOrUpdateRequest, app string,
 	}
 
 	if createResponse.StatusCode != http.StatusCreated && createResponse.StatusCode != http.StatusOK {
-		return errors.New(fmt.Sprintf("Create request failed: %s, %+v", createResponse.Status, res))
+		return errors.New(fmt.Sprintf("Create request failed: %s, %+v", createResponse.Status, createResponse))
 	}
 	return nil
 }
@@ -187,7 +187,7 @@ func (a *MachineAPI) UpdateMachine(req MachineCreateOrUpdateRequest, app string,
 		return err
 	}
 	if reqRes.StatusCode != http.StatusCreated && reqRes.StatusCode != http.StatusOK {
-		return errors.New(fmt.Sprintf("Update request failed: %s, %+v", reqRes.Status, res))
+		return errors.New(fmt.Sprintf("Update request failed: %s, %+v", reqRes.Status, reqRes))
 	}
 	return nil
 }


### PR DESCRIPTION
Currently the parsed payloads are being logged rather than the http response - in the case of an error these contain no information.

This turns
```
Create request failed: 422 Unprocessable Entity, &{ID: Name: State: Region: InstanceID: PrivateIP: Config:{Env:map[] Init:{Exec:[] Entrypoint:[] Cmd:[]} Image: Metadata:<nil> Restart:{Policy:}
Services:[] Mounts:[] Guest:{CPUKind: Cpus:0 MemoryMb:0}} ImageRef:{Registry: Repository: Tag: Digest: Labels:{}} CreatedAt:0001-01-01 00:00:00 +0000 UTC}
```
into
```
Create request failed: 422 Unprocessable Entity, {"error":"Authentication required to access image \"docker.io/library/my-app:my-image\""}
```
for example