### PR TITLE
Incorrect variable in the provider example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ description: |-
 ```terraform
 provider "fly" {
   # Please don't do this. Use the FLY_API_TOKEN env variable instead.
-  flytoken = "abc123"
+  fly_api_token = "abc123"
 }
 ```
 


### PR DESCRIPTION
The variable "flytoken" is changed to "fly_api_token".