### PR TITLE
Build with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.19-bullseye
+
+WORKDIR $GOPATH/src/github.com/fly-apps/terraform-provider-fly
+COPY go.mod .
+RUN go mod download -x
+RUN mkdir -p /out/
+
+COPY . .
+RUN go env; go install; cp $GOPATH/bin/terraform-provider-fly /out/
+
+WORKDIR $GOPATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
-FROM golang:1.19-bullseye
+FROM golang:1.20-bullseye
 
+RUN mkdir -p $GOPATH/src/github.com/fly-apps/terraform-provider-fly
 WORKDIR $GOPATH/src/github.com/fly-apps/terraform-provider-fly
-COPY go.mod .
-RUN go mod download -x
-RUN mkdir -p /out/
 
-COPY . .
-RUN go env; go install; cp $GOPATH/bin/terraform-provider-fly /out/
-
-WORKDIR $GOPATH
+CMD go mod tidy; go build

--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ To run acceptance tests for this provider some scaffolding is required.
 4. Got to the infra directory and run `terraform apply` to create the scaffolding.
 5. You should now be able to run `make` in the repo root to run tests.
 6. (Optional) set FLY_TF_TEST_REGION in `.make-overrides` to a region closer to you
+
+### Building with Docker
+If you don't have a local Go environment, you can build in a container:
+
+```
+docker build --pull -t provider-fly:latest .
+docker run --rm --entrypoint=cat provider-fly:latest /out/terraform-provider-fly > terraform-provider-fly
+```

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ To run acceptance tests for this provider some scaffolding is required.
 6. (Optional) set FLY_TF_TEST_REGION in `.make-overrides` to a region closer to you
 
 ### Building with Docker
-If you don't have a local Go environment, you can build in a container:
+If you do not have a local Go environment, you can build in a container. The binary will be placed in the root of the repository.
 
-```
-docker build --pull -t provider-fly:latest .
-docker run --rm --entrypoint=cat provider-fly:latest /out/terraform-provider-fly > terraform-provider-fly
-```
+If you are not building for linux, set `GOOS` and `GOARCH` environment variables appropriately.
+
+* `docker-compose up` (default, linux build)
+* `GOOS=darwin GOARCH=arm64 docker-compose up` (m1 mac)
+* `docker-compose up --build` if the version of golang has changed since the last run.

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,10 @@
+services:
+  build:
+    build:
+      context: .
+    environment:
+      - GOOS
+      - GOARCH
+    image: provider-fly
+    volumes:
+     - .:/go/src/github.com/fly-apps/terraform-provider-fly


### PR DESCRIPTION
Replacement for #109 rebased onto current main history

@ryansch
> I don't have a local Go toolchain. I've been using docker to build my own versions of the fly provider and wondered if this would be useful for others.
