### PR TITLE
Expose shared IPv4 address through app data source

### DIFF
--- a/docs/data-sources/app.md
+++ b/docs/data-sources/app.md
@@ -37,4 +37,5 @@ data "fly_app" "example" {
 - `hostname` (String)
 - `id` (String) The ID of this resource.
 - `ipaddresses` (List of String)
+- `sharedipaddress` (String)
 - `status` (String)

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -498,20 +498,21 @@ func (v *GetCertificateResponse) GetApp() GetCertificateApp { return v.App }
 
 // GetFullAppApp includes the requested fields of the GraphQL type App.
 type GetFullAppApp struct {
-	Name           string                                        `json:"name"`
-	Network        string                                        `json:"network"`
-	Organization   GetFullAppAppOrganization                     `json:"organization"`
-	Autoscaling    GetFullAppAppAutoscalingAutoscalingConfig     `json:"autoscaling"`
-	AppUrl         string                                        `json:"appUrl"`
-	Hostname       string                                        `json:"hostname"`
-	Id             string                                        `json:"id"`
-	Status         string                                        `json:"status"`
-	Deployed       bool                                          `json:"deployed"`
-	CurrentRelease GetFullAppAppCurrentRelease                   `json:"currentRelease"`
-	Config         GetFullAppAppConfig                           `json:"config"`
-	HealthChecks   GetFullAppAppHealthChecksCheckStateConnection `json:"healthChecks"`
-	IpAddresses    GetFullAppAppIpAddressesIPAddressConnection   `json:"ipAddresses"`
-	Role           GetFullAppAppRole                             `json:"-"`
+	Name            string                                        `json:"name"`
+	Network         string                                        `json:"network"`
+	Organization    GetFullAppAppOrganization                     `json:"organization"`
+	Autoscaling     GetFullAppAppAutoscalingAutoscalingConfig     `json:"autoscaling"`
+	AppUrl          string                                        `json:"appUrl"`
+	Hostname        string                                        `json:"hostname"`
+	Id              string                                        `json:"id"`
+	Status          string                                        `json:"status"`
+	Deployed        bool                                          `json:"deployed"`
+	CurrentRelease  GetFullAppAppCurrentRelease                   `json:"currentRelease"`
+	Config          GetFullAppAppConfig                           `json:"config"`
+	HealthChecks    GetFullAppAppHealthChecksCheckStateConnection `json:"healthChecks"`
+	SharedIpAddress string                                        `json:"sharedIpAddress"`
+	IpAddresses     GetFullAppAppIpAddressesIPAddressConnection   `json:"ipAddresses"`
+	Role            GetFullAppAppRole                             `json:"-"`
 }
 
 // GetName returns GetFullAppApp.Name, and is useful for accessing the field via an interface.
@@ -553,6 +554,9 @@ func (v *GetFullAppApp) GetConfig() GetFullAppAppConfig { return v.Config }
 func (v *GetFullAppApp) GetHealthChecks() GetFullAppAppHealthChecksCheckStateConnection {
 	return v.HealthChecks
 }
+
+// GetSharedIpAddress returns GetFullAppApp.SharedIpAddress, and is useful for accessing the field via an interface.
+func (v *GetFullAppApp) GetSharedIpAddress() string { return v.SharedIpAddress }
 
 // GetIpAddresses returns GetFullAppApp.IpAddresses, and is useful for accessing the field via an interface.
 func (v *GetFullAppApp) GetIpAddresses() GetFullAppAppIpAddressesIPAddressConnection {
@@ -620,6 +624,8 @@ type __premarshalGetFullAppApp struct {
 
 	HealthChecks GetFullAppAppHealthChecksCheckStateConnection `json:"healthChecks"`
 
+	SharedIpAddress string `json:"sharedIpAddress"`
+
 	IpAddresses GetFullAppAppIpAddressesIPAddressConnection `json:"ipAddresses"`
 
 	Role json.RawMessage `json:"role"`
@@ -648,6 +654,7 @@ func (v *GetFullAppApp) __premarshalJSON() (*__premarshalGetFullAppApp, error) {
 	retval.CurrentRelease = v.CurrentRelease
 	retval.Config = v.Config
 	retval.HealthChecks = v.HealthChecks
+	retval.SharedIpAddress = v.SharedIpAddress
 	retval.IpAddresses = v.IpAddresses
 	{
 
@@ -1915,6 +1922,7 @@ query GetFullApp ($name: String) {
 				status
 			}
 		}
+		sharedIpAddress
 		ipAddresses {
 			nodes {
 				address

--- a/graphql/genqlient.graphql
+++ b/graphql/genqlient.graphql
@@ -29,6 +29,7 @@ query GetFullApp($name: String) {
                 status
             }
         }
+        sharedIpAddress
         ipAddresses {
             nodes {
                 address

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -268,6 +268,7 @@ type App implements Node {
     # Returns the last _n_ elements from the list.
     last: Int
   ): IPAddressConnection!
+  sharedIpAddress: String
 
   # This object's unique key
   key: String!

--- a/internal/provider/app_data_source.go
+++ b/internal/provider/app_data_source.go
@@ -38,15 +38,16 @@ func (d *appDataSourceType) Configure(_ context.Context, req datasource.Configur
 }
 
 type appDataSourceOutput struct {
-	Name           types.String `tfsdk:"name"`
-	AppUrl         types.String `tfsdk:"appurl"`
-	Hostname       types.String `tfsdk:"hostname"`
-	Id             types.String `tfsdk:"id"`
-	Status         types.String `tfsdk:"status"`
-	Deployed       types.Bool   `tfsdk:"deployed"`
-	Healthchecks   []string     `tfsdk:"healthchecks"`
-	Ipaddresses    []string     `tfsdk:"ipaddresses"`
-	Currentrelease types.String `tfsdk:"currentrelease"`
+	Name            types.String `tfsdk:"name"`
+	AppUrl          types.String `tfsdk:"appurl"`
+	Hostname        types.String `tfsdk:"hostname"`
+	Id              types.String `tfsdk:"id"`
+	Status          types.String `tfsdk:"status"`
+	Deployed        types.Bool   `tfsdk:"deployed"`
+	Healthchecks    []string     `tfsdk:"healthchecks"`
+	Ipaddresses     []string     `tfsdk:"ipaddresses"`
+	Sharedipaddress types.String `tfsdk:"sharedipaddress"`
+	Currentrelease  types.String `tfsdk:"currentrelease"`
 }
 
 func (d *appDataSourceType) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -81,6 +82,9 @@ func (d *appDataSourceType) Schema(_ context.Context, _ datasource.SchemaRequest
 				Computed:    true,
 				ElementType: types.StringType,
 			},
+			"sharedipaddress": schema.StringAttribute{
+				Computed: true,
+			},
 			"currentrelease": schema.StringAttribute{
 				Computed: true,
 			},
@@ -107,13 +111,14 @@ func (d *appDataSourceType) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	a := appDataSourceOutput{
-		Name:           data.Name,
-		AppUrl:         types.StringValue(queryresp.App.AppUrl),
-		Hostname:       types.StringValue(queryresp.App.Hostname),
-		Id:             types.StringValue(queryresp.App.Id),
-		Status:         types.StringValue(queryresp.App.Status),
-		Deployed:       types.BoolValue(queryresp.App.Deployed),
-		Currentrelease: types.StringValue(queryresp.App.CurrentRelease.Id),
+		Name:            data.Name,
+		AppUrl:          types.StringValue(queryresp.App.AppUrl),
+		Hostname:        types.StringValue(queryresp.App.Hostname),
+		Id:              types.StringValue(queryresp.App.Id),
+		Status:          types.StringValue(queryresp.App.Status),
+		Deployed:        types.BoolValue(queryresp.App.Deployed),
+		Sharedipaddress: types.StringValue(queryresp.App.SharedIpAddress),
+		Currentrelease:  types.StringValue(queryresp.App.CurrentRelease.Id),
 	}
 
 	for _, s := range queryresp.App.HealthChecks.Nodes {


### PR DESCRIPTION
I've added the shared IPv4 address to the app data source, as it is missing in the list of IP addresses attached to the app. Another solution would maybe be to append it to the existing list. Even better would be to have it "managed" somehow by the `fly_ip` resource with a `shared_v4` type.