### PR TITLE
Add support for `auto_destroy`

### DIFF
--- a/pkg/apiv1/machines.go
+++ b/pkg/apiv1/machines.go
@@ -3,10 +3,11 @@ package apiv1
 import (
 	"errors"
 	"fmt"
-	"github.com/Khan/genqlient/graphql"
-	hreq "github.com/imroc/req/v3"
 	"net/http"
 	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	hreq "github.com/imroc/req/v3"
 )
 
 var NonceHeader = "fly-machine-lease-nonce"
@@ -42,12 +43,13 @@ type InitConfig struct {
 }
 
 type MachineConfig struct {
-	Image    string            `json:"image"`
-	Env      map[string]string `json:"env"`
-	Init     InitConfig        `json:"init,omitempty"`
-	Mounts   []MachineMount    `json:"mounts,omitempty"`
-	Services []Service         `json:"services"`
-	Guest    GuestConfig       `json:"guest,omitempty"`
+	Image       string            `json:"image"`
+	Env         map[string]string `json:"env"`
+	Init        InitConfig        `json:"init,omitempty"`
+	Mounts      []MachineMount    `json:"mounts,omitempty"`
+	Services    []Service         `json:"services"`
+	Guest       GuestConfig       `json:"guest,omitempty"`
+	AutoDestroy bool              `json:"auto_destroy"`
 }
 
 type GuestConfig struct {
@@ -89,6 +91,7 @@ type MachineResponse struct {
 			Cpus     int    `json:"cpus"`
 			MemoryMb int    `json:"memory_mb"`
 		} `json:"guest"`
+		AutoDestroy bool `json:"auto_destroy"`
 	} `json:"config"`
 	ImageRef struct {
 		Registry   string `json:"registry"`


### PR DESCRIPTION
Adding support for `auto_destroy` property on machines. Default value is set to `false`

---

Closes: https://github.com/fly-apps/terraform-provider-fly/issues/233