### PR TITLE
Add support for `force_https` on handlers

### DIFF
--- a/internal/provider/machine_resource.go
+++ b/internal/provider/machine_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -39,8 +40,9 @@ func (r *flyMachineResource) Configure(_ context.Context, req resource.Configure
 }
 
 type TfPort struct {
-	Port     types.Int64    `tfsdk:"port"`
-	Handlers []types.String `tfsdk:"handlers"`
+	Port       types.Int64    `tfsdk:"port"`
+	Handlers   []types.String `tfsdk:"handlers"`
+	ForceHttps bool           `tfsdk:"force_https"`
 }
 
 type TfService struct {
@@ -195,6 +197,12 @@ func (r *flyMachineResource) Schema(_ context.Context, _ resource.SchemaRequest,
 										Optional:            true,
 										ElementType:         types.StringType,
 									},
+									"force_https": schema.BoolAttribute{
+										MarkdownDescription: "Automatically redirect to HTTPS on \"http\" handler",
+										Computed:            true,
+										Optional:            true,
+										Default:             booldefault.StaticBool(false),
+									},
 								},
 							},
 						},
@@ -223,8 +231,9 @@ func TfServicesToServices(input []TfService) []apiv1.Service {
 				handlers = append(handlers, k.ValueString())
 			}
 			ports = append(ports, apiv1.Port{
-				Port:     j.Port.ValueInt64(),
-				Handlers: handlers,
+				Port:       j.Port.ValueInt64(),
+				Handlers:   handlers,
+				ForceHttps: j.ForceHttps,
 			})
 		}
 		services = append(services, apiv1.Service{
@@ -246,8 +255,9 @@ func ServicesToTfServices(input []apiv1.Service) []TfService {
 				handlers = append(handlers, types.StringValue(k))
 			}
 			tfports = append(tfports, TfPort{
-				Port:     types.Int64Value(j.Port),
-				Handlers: handlers,
+				Port:       types.Int64Value(j.Port),
+				Handlers:   handlers,
+				ForceHttps: j.ForceHttps,
 			})
 		}
 		tfservices = append(tfservices, TfService{

--- a/pkg/apiv1/machines.go
+++ b/pkg/apiv1/machines.go
@@ -3,10 +3,11 @@ package apiv1
 import (
 	"errors"
 	"fmt"
-	"github.com/Khan/genqlient/graphql"
-	hreq "github.com/imroc/req/v3"
 	"net/http"
 	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	hreq "github.com/imroc/req/v3"
 )
 
 var NonceHeader = "fly-machine-lease-nonce"
@@ -25,8 +26,9 @@ type MachineMount struct {
 }
 
 type Port struct {
-	Port     int64    `json:"port"`
-	Handlers []string `json:"handlers"`
+	Port       int64    `json:"port"`
+	Handlers   []string `json:"handlers"`
+	ForceHttps bool     `json:"force_https"`
 }
 
 type Service struct {


### PR DESCRIPTION
Adding support for `force_https` property on HTTP handlers. Default value is set to `false`

---

Closes: https://github.com/fly-apps/terraform-provider-fly/issues/170